### PR TITLE
fix: pin GitHub Actions to SHA for supply chain security

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Build
       run: cargo build --verbose
     - name: Run rustfmt


### PR DESCRIPTION
## Summary

Pin all GitHub Actions to full commit SHAs for supply chain security.

Actions referenced by tag or branch have been resolved to their commit SHA, with the original ref preserved as an inline comment. Where a sub-action had unpinned transitive dependencies, the action was upgraded to the closest newer version where all sub-actions are fully pinned.

References to this repo's own reusable workflows / composite actions have been rewritten to relative `./` paths, which run from the current commit and are exempt from SHA-pinning enforcement.
